### PR TITLE
Fix travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ python:
   - "pypy"
 # command to install dependencies
 install:
-  - pip install . --use-mirrors
+  - pip install . 
 # command to run tests
 script: nosetests


### PR DESCRIPTION
As per the following: https://github.com/pypa/pip/pull/1098

The --use-mirrors argument for travis.yml was deprecated in 2015.

pip builds for 2.7 used before this change fail during automated
testing with 'no option --use-mirrors'