### PR TITLE
Add a GitHub workflow to create a Windows standalone app on each release

### DIFF
--- a/.github/workflows/pyinstaller.yml
+++ b/.github/workflows/pyinstaller.yml
@@ -1,0 +1,40 @@
+name: pyinstaller
+
+on:
+  release:
+    types: [published]
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+    - name: Install dependencies and package
+      run: |
+        python -m pip install --upgrade pip
+        pip install PyInstaller
+        pip install .
+    - name: Build with PyInstaller
+      run: |
+        pyinstaller.exe totalopenstation-gui.spec
+    - name: Get version from latest release
+      id: get_version
+      uses: battila7/get-version-action@v2
+    - name: Upload Release Asset
+      id: upload-release-asset 
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./dist/totalopenstation.exe
+        asset_name: totalopenstation_x64_${{ steps.get_version.outputs.version-without-v }}.exe
+        asset_content_type: application/octet-stream


### PR DESCRIPTION
This fixes #94 with a GitHub workflow. There is no automatic release, the .exe file is built after the release is published and then automatically uploaded.