### PR TITLE
Fix import KeyboardInterrupt

### DIFF
--- a/totalopenstation/models/__init__.py
+++ b/totalopenstation/models/__init__.py
@@ -25,7 +25,6 @@ import sys
 
 from time import sleep
 from threading import Event, Thread
-from threading.exceptions import KeyboardInterrupt
 
 from totalopenstation.utils.upref import UserPrefs
 


### PR DESCRIPTION
Fix this error:

```
    from threading.exceptions import KeyboardInterrupt
ModuleNotFoundError: No module named 'threading.exceptions'; 'threading' is not a package
```

`KeyboardInterrupt` is a base exception, and it's not required to import it (and one can't import `KeyboardInterrupt` like this)
